### PR TITLE
Add platform option to build command of build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -100,7 +100,7 @@ def _create_rootfs_container(src_dir, build_dir, container_name, version):
     if not os.path.exists(container_file):
         _errorhandler(f"File does not exist: {container_file}")
 
-    command_list = [_tool(), 'build', '-f', container_file, '-t', container_image, src_dir]
+    command_list = [_tool(), 'build', '--platform', 'linux/arm/v7', '-f', container_file, '-t', container_image, src_dir]
     if subprocess.call(command_list) != 0:
         _errorhandler("Could not build docker image!")
 


### PR DESCRIPTION
Helps to use images which are not implicitely declared for platform arm32v7

When we tried build SIAPP from image arm32v7/python:3.11-slim on debian ubuntu, It was needed to change build command.